### PR TITLE
Fix contextless 'Not Found' error logging on startup, bump to 0.4.5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+- This repo publishes three separate npm packages from three long-lived branches off the same history: `dev` (current/default), `teslemetry` (`homebridge-teslemetry`), and `tessie`. Each branch has its own `package.json` version and dependency set; a fix for one published package must be branched from and PR'd against that package's branch, not `dev`. `publish.sh` walks all three branches and runs `npm publish` from each - it is run manually, not via CI.
+- No automated tests exist. Verify changes by building (`npm run build`), linting (`npm run lint`), and, for logic changes, a throwaway smoke script that imports the compiled `dist/*.js`, mocks the `homebridge` `log`/`api` objects, and drives the relevant code path - see recent PR history for the pattern.
+- `tesla-fleet-api`'s `_request()` rejects with a plain `{ status, data }` object (not an `Error`) when the Tesla/Teslemetry API returns a non-OK HTTP response, where `data` is the parsed JSON error body (often `{ error: "<message>" }`). Any `.catch()` on a `tesla-fleet-api` call should destructure `{ status, data }` and log the operation name plus `data?.error` (or the raw error as a fallback for non-API-shaped rejections like network failures) - never log a caught error bare, since that produces contextless output like a bare `Not Found`.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "engines": {
     "node": "^18.20.4 || ^20.15.1 || ^22",
     "homebridge": "^1.6.0 || ^2.0.0-beta.0"

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -59,113 +59,139 @@ export class TeslaFleetApiPlatform implements DynamicPlatformPlugin {
       // run the method to discover / register your devices as accessories
 
       this.TeslaFleetApi.metadata()
-        .then(({ scopes }) =>
-          this.TeslaFleetApi.products_by_type().then(
-            async ({ vehicles, energy_sites }) => {
-              const newAccessories: PlatformAccessory<
-                VehicleContext | EnergyContext
-              >[] = [];
-              if (scopes.includes("vehicle_device_data")) {
-                //const newVehicleAccessories: PlatformAccessory<VehicleContext>[] = [];
-                vehicles.forEach(async (product) => {
-                  if (this.config?.ignore_vin?.includes(product.vin)) {
-                    this.log.info("Ignoring vehicle", product.vin);
-                    return;
-                  }
-                  this.TeslaFleetApi.vehicle!;
-                  const name = product.display_name || "Tesla";
-                  const uuid = this.api.hap.uuid.generate(
-                    `${PLATFORM_NAME}:${product.vin}`,
-                  );
-                  let accessory = this.accessories.find(
-                    (accessory) => accessory.UUID === uuid,
-                  ) as PlatformAccessory<VehicleContext> | undefined;
-
-                  if (accessory) {
-                    this.log.debug(
-                      "Restored existing accessory from cache:",
-                      accessory.displayName,
+        .catch((error) => {
+          const { status, data } = error ?? {};
+          this.log.error(
+            data?.error
+              ? `Teslemetry metadata request failed (status ${status}): ${data.error}`
+              : `Teslemetry metadata request failed: ${error}`,
+          );
+          return null;
+        })
+        .then((metadata) => {
+          if (!metadata) {
+            return null;
+          }
+          const { scopes } = metadata;
+          return this.TeslaFleetApi.products_by_type()
+            .catch((error) => {
+              const { status, data } = error ?? {};
+              this.log.error(
+                data?.error
+                  ? `Teslemetry products request failed (status ${status}): ${data.error}`
+                  : `Teslemetry products request failed: ${error}`,
+              );
+              return null;
+            })
+            .then(
+              async (products) => {
+                if (!products) {
+                  return null;
+                }
+                const { vehicles, energy_sites } = products;
+                const newAccessories: PlatformAccessory<
+                  VehicleContext | EnergyContext
+                >[] = [];
+                if (scopes.includes("vehicle_device_data")) {
+                  //const newVehicleAccessories: PlatformAccessory<VehicleContext>[] = [];
+                  vehicles.forEach(async (product) => {
+                    if (this.config?.ignore_vin?.includes(product.vin)) {
+                      this.log.info("Ignoring vehicle", product.vin);
+                      return;
+                    }
+                    this.TeslaFleetApi.vehicle!;
+                    const name = product.display_name || "Tesla";
+                    const uuid = this.api.hap.uuid.generate(
+                      `${PLATFORM_NAME}:${product.vin}`,
                     );
-                  } else {
-                    this.log.debug("Adding new accessory:", name);
-                    accessory = new this.api.platformAccessory<VehicleContext>(
-                      name,
-                      uuid,
-                      Categories.OTHER,
+                    let accessory = this.accessories.find(
+                      (accessory) => accessory.UUID === uuid,
+                    ) as PlatformAccessory<VehicleContext> | undefined;
+
+                    if (accessory) {
+                      this.log.debug(
+                        "Restored existing accessory from cache:",
+                        accessory.displayName,
+                      );
+                    } else {
+                      this.log.debug("Adding new accessory:", name);
+                      accessory =
+                        new this.api.platformAccessory<VehicleContext>(
+                          name,
+                          uuid,
+                          Categories.OTHER,
+                        );
+                      newAccessories.push(accessory);
+                    }
+
+                    accessory.context.vin = product.vin;
+                    accessory.context.state = product.state;
+                    accessory.displayName = name;
+
+                    new VehicleAccessory(this, accessory);
+                  });
+                }
+
+                if (scopes.includes("energy_device_data")) {
+                  //const newEnergyAccessories: PlatformAccessory<EnergyContext>[] = [];
+                  energy_sites.forEach((product) => {
+                    if (
+                      this.config?.ignore_site?.includes(product.asset_site_id)
+                    ) {
+                      this.log.info(
+                        "Ignoring energy site",
+                        product.energy_site_id,
+                      );
+                      return;
+                    }
+                    this.TeslaFleetApi.energy!;
+                    const name = product.site_name || "Tesla Energy";
+                    const uuid = this.api.hap.uuid.generate(
+                      `${PLATFORM_NAME}:${product.id}`,
                     );
-                    newAccessories.push(accessory);
-                  }
+                    let accessory = this.accessories.find(
+                      (accessory) => accessory.UUID === uuid,
+                    ) as PlatformAccessory<EnergyContext> | undefined;
 
-                  accessory.context.vin = product.vin;
-                  accessory.context.state = product.state;
-                  accessory.displayName = name;
+                    if (accessory) {
+                      this.log.debug(
+                        "Restoring existing accessory from cache:",
+                        accessory.displayName,
+                      );
+                    } else {
+                      this.log.debug("Adding new accessory:", name);
+                      accessory =
+                        new this.api.platformAccessory<EnergyContext>(
+                          name,
+                          uuid,
+                          Categories.OTHER,
+                        );
+                      newAccessories.push(accessory);
+                    }
 
-                  new VehicleAccessory(this, accessory);
-                });
-              }
+                    accessory.context.id = product.energy_site_id;
+                    accessory.context.battery = product.components.battery;
+                    accessory.context.grid = product.components.grid;
+                    accessory.context.solar = product.components.solar;
+                    accessory.displayName = name;
 
-              if (scopes.includes("energy_device_data")) {
-                //const newEnergyAccessories: PlatformAccessory<EnergyContext>[] = [];
-                energy_sites.forEach((product) => {
-                  if (
-                    this.config?.ignore_site?.includes(product.asset_site_id)
-                  ) {
-                    this.log.info(
-                      "Ignoring energy site",
-                      product.energy_site_id,
-                    );
-                    return;
-                  }
-                  this.TeslaFleetApi.energy!;
-                  const name = product.site_name || "Tesla Energy";
-                  const uuid = this.api.hap.uuid.generate(
-                    `${PLATFORM_NAME}:${product.id}`,
-                  );
-                  let accessory = this.accessories.find(
-                    (accessory) => accessory.UUID === uuid,
-                  ) as PlatformAccessory<EnergyContext> | undefined;
+                    new EnergyAccessory(this, accessory);
+                  });
+                }
 
-                  if (accessory) {
-                    this.log.debug(
-                      "Restoring existing accessory from cache:",
-                      accessory.displayName,
-                    );
-                  } else {
-                    this.log.debug("Adding new accessory:", name);
-                    accessory = new this.api.platformAccessory<EnergyContext>(
-                      name,
-                      uuid,
-                      Categories.OTHER,
-                    );
-                    newAccessories.push(accessory);
-                  }
-
-                  accessory.context.id = product.energy_site_id;
-                  accessory.context.battery = product.components.battery;
-                  accessory.context.grid = product.components.grid;
-                  accessory.context.solar = product.components.solar;
-                  accessory.displayName = name;
-
-                  new EnergyAccessory(this, accessory);
-                });
-              }
-
-              return newAccessories;
-            },
-          ),
-        )
-        .then(
-          (newAccessories) => {
+                return newAccessories;
+              },
+            );
+        })
+        .then((newAccessories) => {
+          if (newAccessories) {
             this.api.registerPlatformAccessories(
               PLUGIN_NAME,
               PLATFORM_NAME,
               newAccessories,
             );
-          },
-          (error) => {
-            this.log.error(error?.data?.error ?? error);
-          },
-        );
+          }
+        });
     });
   }
 


### PR DESCRIPTION
## Intent

- Fix contextless error logging that produced a repeating bare `[Teslemetry] Not Found` log with no indication of what failed (npm `homebridge-teslemetry` 0.4.4, reported by a user)
  - Root cause: `platform.ts`'s `didFinishLaunching` handler caught the account-discovery API chain (`metadata()` -> `products_by_type()`) with a single `this.log.error(error?.data?.error ?? error)`. `tesla-fleet-api`'s `_request()` rejects with `{ status, data }` on any non-OK HTTP response, so a 404 logs literally just the string `"Not Found"` - no operation name, no status code, nothing.
  - Fix: `metadata()` and `products_by_type()` now each have their own `.catch()` that logs the operation name, HTTP status, and error body (`data.error`), falling back to the full error object for non-API-shaped rejections (e.g. network failures). Matches the `${op} failed: ${status}: ${data.error}` logging pattern already used in `vehicle.ts`/`energy.ts`.
  - Reproduced by mocking `metadata()` to reject with `{status: 404, data: {error: "Not Found"}}` against the compiled `dist/platform.js` and confirming the current code logs bare `"Not Found"`; confirmed the fix logs `Teslemetry metadata request failed (status 404): Not Found` instead.
  - Same corrected pattern applied to `products_by_type()` failures (e.g. a 500).
  - This is a stopgap fix on the legacy `teslemetry` branch. The root cause was already fixed properly in the new (private, unpublished) monorepo plugin; this port keeps npm users unblocked in the meantime.
- Library update assessment: `tesla-fleet-api` pinned at `^0.2.0` is already the latest published version (0.2.0, published 2024-07-21) - no newer release exists, so **no dependency bump was made or needed**.
- Version bump: `0.4.4` -> `0.4.5` in `package.json`.

## What Changed

- `src/platform.ts`: split the single `.then(..., errorHandler)` at the end of the metadata/products discovery chain into per-call `.catch()` handlers with contextual messages; downstream logic (accessory creation, registration) is unchanged, just reindented under the new nesting.
- `package.json`: version `0.4.4` -> `0.4.5`.
- `AGENTS.md` (new): documents the multi-branch publish model and the `tesla-fleet-api` `{status, data}` rejection shape, so future error-logging fixes in this repo follow the same pattern.

## Risk Assessment

Low. The change only affects the `.catch()` branches of the startup account-discovery chain - the success path (accessory creation/registration) is untouched logic, just re-indented. No dependency version changed. Verified with `tsc --noEmit`, `eslint --max-warnings=0`, and `npm run build`, all clean.

## Testing

- `npx tsc --noEmit` - passes.
- `npm run lint` - passes with `--max-warnings=0`.
- `npm run build` - passes.
- No test suite exists in this repo. Did a smoke-level sanity check instead: imported the compiled `dist/platform.js`, constructed `TeslaFleetApiPlatform` with mocked `homebridge` `log`/`api` objects, and drove `didFinishLaunching` through four scenarios:
  1. `metadata()` rejects with `{status: 404, data: {error: "Not Found"}}` -> logs `Teslemetry metadata request failed (status 404): Not Found` (previously bare `Not Found`).
  2. `products_by_type()` rejects with `{status: 500, data: {error: "Internal Server Error"}}` -> logs `Teslemetry products request failed (status 500): Internal Server Error`.
  3. `metadata()` rejects with a plain `TypeError("fetch failed")` (non-API-shaped, e.g. network failure) -> logs `Teslemetry metadata request failed: TypeError: fetch failed` instead of `status undefined: undefined`.
  4. Happy path (`metadata()`/`products_by_type()` resolve, empty scopes/products) -> no error logs, `registerPlatformAccessories` still called correctly.

Publishing remains manual via `publish.sh` - that step is the captain's, after merge.

<details><summary>Full narrative / original brief</summary>

STOPGAP fix for the published HomeBridge plugin (npm `homebridge-teslemetry` 0.4.4), which builds from this repo's `teslemetry` branch, not the default `dev` branch.

A user reported the plugin failing with only a bare `[Teslemetry] Not Found` log line repeating, with zero context about what failed. That defect was root-caused and fixed in the new monorepo plugin (contextless error logging on a streaming/config-update failure path), but the monorepo plugin is private/unpublished, so npm users run this legacy code. This PR pushes the fix here as a stopgap, together with a library-update assessment (`tesla-fleet-api` is already at latest), and bumps the package version to 0.4.5.

</details>
