### PR TITLE
Stop logging accessToken during platform construction

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -42,7 +42,7 @@ export class TeslaFleetApiPlatform implements DynamicPlatformPlugin {
 
     this.TeslaFleetApi = new Teslemetry(this.config.accessToken);
 
-    this.log.debug("Finished initializing platform:", this.config.accessToken);
+    this.log.debug("Finished initializing platform, accessToken configured:", !!this.config.accessToken);
 
     // Homebridge 1.8.0 introduced a `log.success` method that can be used to log success messages
     // For users that are on a version prior to 1.8.0, we need a 'polyfill' for this method


### PR DESCRIPTION
## What

- `platform.ts` logged the raw `accessToken` value to debug logs on every platform construction.
- Credentials must never be logged. Replaced the value with a boolean `accessToken configured: true/false` so the debug log stays useful without exposing the secret.
- Scanned the rest of `src/` for other credential-logging spots; found none.