### PR TITLE
Fix inverted Charge From Grid switch state on refresh

### DIFF
--- a/src/energy-services/chargefromgrid.ts
+++ b/src/energy-services/chargefromgrid.ts
@@ -18,7 +18,7 @@ export class ChargeFromGrid extends BaseService {
 
     this.parent.emitter.on("site_info", (data) => {
       if (typeof data.components.disallow_charge_from_grid_with_solar_installed === "boolean") {
-        on.updateValue(data.components.disallow_charge_from_grid_with_solar_installed);
+        on.updateValue(!data.components.disallow_charge_from_grid_with_solar_installed);
       }
     });
   }


### PR DESCRIPTION
## Intent

- Fix Charge From Grid switch showing the inverted state after a refresh (found by user report)
  - Root cause: `chargefromgrid.ts`'s `site_info` listener wrote the raw `disallow_charge_from_grid_with_solar_installed` value straight to the `On` characteristic, while the `onSet` handler treats the switch as the inverse of that API value (`!value`) when sending commands
  - Fix: apply the same inversion on read (`on.updateValue(!data.components.disallow_charge_from_grid_with_solar_installed)`) so refreshed state matches SET semantics
  - No behavior change to the SET path; read and write are now consistent
