### PR TITLE
Make CI deterministic: pnpm frozen install, pinned actions, real tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,30 +9,39 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # the Node.js versions to build on
-        node-version: [18.x, 20.x]
+        # Supported Node.js versions per the "engines" field in package.json
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Use Node.js ${{ matrix.node-version }} 
-        uses: actions/setup-node@v3
+      - uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: pnpm
 
-      - name: Install dependencies
-        run: npm install
+      - name: Install dependencies (frozen lockfile)
+        run: pnpm install --frozen-lockfile
 
       - name: Lint the project
-        run: npm run lint
+        run: pnpm run lint
 
-      - name: Build the project
-        run: npm run build
+      - name: Compile TypeScript
+        run: pnpm run build
 
-      - name: List, audit, fix outdated dependencies and build again
+      - name: Run tests
+        run: pnpm test
+
+      - name: Inspect package tarball
         run: |
-          npm list --outdated
-          npm audit || true  # ignore failures
-          npm audit fix || true
-          npm list --outdated
-          npm run build
+          pnpm pack
+          tar -tzf *.tgz | sort
+          tar -tzf *.tgz | grep -q '^package/dist/index.js$'
+          rm -f *.tgz
+
+      - name: Audit dependencies (advisory only)
+        if: matrix.node-version == '20.x'
+        run: pnpm audit || true

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore compiled code
 dist
+dist-test
 
 # ------------- Defaults ------------- #
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+- This repo publishes three separate npm packages from three long-lived branches off the same history: `dev` (current/default), `teslemetry` (`homebridge-teslemetry`), and `tessie`. Each branch has its own `package.json` version and dependency set; a fix for one published package must be branched from and PR'd against that package's branch, not `dev`. `publish.sh` walks all three branches and runs `npm publish` from each - it is run manually, not via CI.
+- CI (`.github/workflows/build.yml`) is currently identical across `dev`, `teslemetry`, and `tessie`; `rebase.sh` rebases the product branches onto `dev`, so a workflow change made on `dev` propagates to the others on the next rebase rather than needing to be duplicated per branch.
+- CI installs with `pnpm install --frozen-lockfile` (this repo's package manager is pinned via the `packageManager` field in `package.json`), and runs lint, build, and test against the committed lockfile - it does not run `npm/pnpm audit fix`, since a CI step that mutates and force-pushes dependency changes defeats a frozen, reproducible install. An advisory-only `pnpm audit` step is fine; it must not fail the build.
+- Most logic changes still have no automated tests. Verify them by building (`npm run build`), linting (`npm run lint`), and, where useful, a throwaway smoke script that imports the compiled `dist/*.js`, mocks the `homebridge` `log`/`api` objects, and drives the relevant code path. A few committed cases do have real tests (e.g. `test/index.test.ts` for plugin registration, `test/platform.test.ts` for config parsing) using node's built-in test runner against fakes for the slice of the HAP/Homebridge API touched - no hap-nodejs/homebridge instance needed. Run them with `npm test` (compiles `src` + `test` via `tsconfig.test.json` into `dist-test`, then runs `node --test`).
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "main": "dist/index.js",
   "scripts": {
     "lint": "eslint src/**/*.ts --max-warnings=0",
-    "test": "tsc -p tsconfig.test.json && node --test dist-test/test/**/*.test.js",
+    "test": "tsc -p tsconfig.test.json && cd dist-test && node --test",
     "fix": "eslint src/**/*.ts --fix",
     "watch": "npm run build && npm link && nodemon",
     "build": "rimraf ./dist && tsc",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "main": "dist/index.js",
   "scripts": {
     "lint": "eslint src/**/*.ts --max-warnings=0",
+    "test": "tsc -p tsconfig.test.json && node --test dist-test/test/**/*.test.js",
     "fix": "eslint src/**/*.ts --fix",
     "watch": "npm run build && npm link && nodemon",
     "build": "rimraf ./dist && tsc",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import registerPlugin from "../src/index.js";
+import { TeslaFleetApiPlatform } from "../src/platform.js";
+import { PLATFORM_NAME, PLUGIN_NAME } from "../src/settings.js";
+
+test("registers the platform under its plugin and platform names", () => {
+  const calls: { pluginName: string; platformName: string; constructor: unknown }[] = [];
+  const fakeApi = {
+    registerPlatform(pluginName: string, platformName: string, constructor: unknown) {
+      calls.push({ pluginName, platformName, constructor });
+    },
+  } as unknown as Parameters<typeof registerPlugin>[0];
+
+  registerPlugin(fakeApi);
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].pluginName, PLUGIN_NAME);
+  assert.equal(calls[0].platformName, PLATFORM_NAME);
+  assert.equal(calls[0].constructor, TeslaFleetApiPlatform);
+});

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { TeslaFleetApiPlatform } from "../src/platform.js";
+
+class FakeService {}
+class FakeCharacteristic {}
+
+function makeFakeApi() {
+  const listeners = new Map<string, () => void>();
+  return {
+    hap: { Service: FakeService, Characteristic: FakeCharacteristic },
+    on(event: string, listener: () => void) {
+      listeners.set(event, listener);
+    },
+    listeners,
+  };
+}
+
+function makeFakeLog() {
+  const calls: { level: string; args: unknown[] }[] = [];
+  return {
+    debug: (...args: unknown[]) => calls.push({ level: "debug", args }),
+    info: (...args: unknown[]) => calls.push({ level: "info", args }),
+    warn: (...args: unknown[]) => calls.push({ level: "warn", args }),
+    error: (...args: unknown[]) => calls.push({ level: "error", args }),
+    calls,
+  };
+}
+
+test("stores the parsed platform config, including array options", () => {
+  const api = makeFakeApi();
+  const config = {
+    platform: "Teslemetry",
+    name: "Teslemetry",
+    accessToken: "test-token",
+    ignore_vin: ["5YJ3E1EA1JF000001"],
+    ignore_site: [12345],
+  };
+
+  const platform = new TeslaFleetApiPlatform(
+    makeFakeLog() as never,
+    config as never,
+    api as never,
+  );
+
+  assert.equal(platform.config.accessToken, "test-token");
+  assert.deepEqual(platform.config.ignore_vin, ["5YJ3E1EA1JF000001"]);
+  assert.deepEqual(platform.config.ignore_site, [12345]);
+});
+
+test("registers a didFinishLaunching listener to discover accessories after cache restore", () => {
+  const api = makeFakeApi();
+  const config = { platform: "Teslemetry", name: "Teslemetry", accessToken: "test-token" };
+
+  new TeslaFleetApiPlatform(makeFakeLog() as never, config as never, api as never);
+
+  assert.equal(typeof api.listeners.get("didFinishLaunching"), "function");
+});
+
+test("polyfills log.success on loggers that predate Homebridge 1.8.0", () => {
+  const api = makeFakeApi();
+  const config = { platform: "Teslemetry", name: "Teslemetry", accessToken: "test-token" };
+  const log = makeFakeLog();
+
+  new TeslaFleetApiPlatform(log as never, config as never, api as never);
+
+  assert.equal((log as unknown as { success: unknown }).success, log.info);
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist-test",
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Intent

- `.github/workflows/build.yml` ran `npm install` against a repo whose package manager is pinned to pnpm (`packageManager` in `package.json`, with a committed `pnpm-lock.yaml`), then unconditionally ran `npm audit fix`, which mutates the dependency tree mid-build - CI wasn't actually evaluating the committed dependency graph, and any auto-applied fix could silently change what gets published.
  - Fix: install with `pnpm install --frozen-lockfile`, pin `actions/checkout` and `actions/setup-node` to v4, add `pnpm/action-setup@v4`, and run the Node matrix across the full supported range (18/20/22, per `engines` in `package.json`).
  - Removed `npm audit fix` entirely. `pnpm audit` stays as an advisory-only step (`|| true`) so a new CVE doesn't block merges but is still visible in CI output.
  - Added a package/tarball inspection step (`pnpm pack` + `tar -tzf`) so a broken `main` entry point or missing build output fails CI instead of only surfacing on publish.
- There was no automated coverage of the plugin's public surface (registration, config parsing). Added `test/index.test.ts` and `test/platform.test.ts` (node's built-in test runner, run via `npm test`) covering:
  - `src/index.ts` registers `TeslaFleetApiPlatform` under the correct plugin/platform names.
  - `src/platform.ts` correctly parses config (including array options like `ignore_vin`/`ignore_site`), registers the `didFinishLaunching` listener, and applies the `log.success` polyfill.
- This repo publishes `dev`/`teslemetry`/`tessie` from long-lived branches, and `.github/workflows/build.yml` is currently identical on all three. `rebase.sh` rebases the product branches onto `dev`, so this change reaches `teslemetry`/`tessie` on the next rebase rather than needing separate PRs. Added an `AGENTS.md` (mirroring the one already present on `teslemetry`) documenting the branch/CI/test conventions for future agent sessions on `dev`.
